### PR TITLE
Add Title Saving, NoteFrame Max-height

### DIFF
--- a/app/renderer/components/commons/Header/index.js
+++ b/app/renderer/components/commons/Header/index.js
@@ -4,9 +4,14 @@ import UserProfile from '../UserProfile'
 
 export default class Header extends Component {
   constructor (props) {
-    super()
+    super(props)
+    let titleValue = 'Sticky Note'
+    if (this.props.id) {
+      const titleValueSaved = window.localStorage.getItem(this.props.id + '__title')
+      if (titleValueSaved) titleValue = titleValueSaved
+    }
     this.state = {
-      titleValue: 'Sticky Note'
+      titleValue: titleValue
     }
   }
 

--- a/app/renderer/components/commons/Header/index.js
+++ b/app/renderer/components/commons/Header/index.js
@@ -15,6 +15,7 @@ export default class Header extends Component {
       titleValue: e.target.value
     })
     document.title = this.state.titleValue
+    window.localStorage.setItem(this.props.id + '__title', this.state.titleValue)
   }
 
   render () {

--- a/app/renderer/components/lobby/NoteFrame/index.js
+++ b/app/renderer/components/lobby/NoteFrame/index.js
@@ -20,6 +20,7 @@ class NoteFrame extends Component {
     const deleteBtnHandler = () => {
       this.props.deleteCallBack(this.props.id)
     }
+    const noteTitle = window.localStorage.getItem(this.props.id + '__title')
     return (
       <div className='note_frame'>
         <div
@@ -32,6 +33,7 @@ class NoteFrame extends Component {
           className='wrapper'
           onClick={this.props.onClick}
         >
+          <h2 className='contents title'>{noteTitle}</h2>
           <p className='contents summary' ref={this.pRef} />
         </div>
       </div>

--- a/app/renderer/noteWindow.js
+++ b/app/renderer/noteWindow.js
@@ -31,6 +31,7 @@ export default class App extends Component {
           title='안녕하세요.'
           editable='true'
           onChange={onChangeHandler}
+          id={this.id}
         />
         <Editor id={this.id} />
         {/* <button onClick={testHandler}>log id</button> */}

--- a/app/sass/sticky-note/components/_note_index.scss
+++ b/app/sass/sticky-note/components/_note_index.scss
@@ -9,10 +9,20 @@
     background-color: $gray_light;
     border-radius: $radius__basic;
     transition: 0.1s ease-in-out;
+    max-height: 150px;
+    overflow: hidden;
 
     .wrapper {
       min-height: 50px;
       padding: 10px;
+
+      .contents.title {
+        font-size: 1.1em;
+        margin: 5px 0;
+      }
+      .contents.summary {
+        font-size: 0.8em;
+      }
     }
 
     .btn {
@@ -29,7 +39,18 @@
     cursor: pointer;
   }
 
-  .note_btn .btn {
-    display: none;
+  .note_btn {
+    .btn {
+      display: none;
+    }
+
+    .wrapper {
+      display: flex;
+      align-items: center;
+
+      .contents.summary {
+        margin: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
 * 이제 노트 타이틀을 저장합니다. (`noteID+'__title'` 형식)
 * 노트 내용이 너무 많이 표시되는 문제를 CSS 스타일로 일부 해결했습니다.
   * 하지만 최대 높이를 걸어두고 넘치는(overflow) 내용을 보이지 않게 설정한 것 뿐이라 추가 작업이 필요합니다.
   * 제가 수정한 부분이 아니기 때문에 코드를 직접 손대기에는 시간이 부족하다고 생각해서 이러한 방향으로 우선 수정했습니다.

resolves #27 (2) (4)